### PR TITLE
Feature to output binary files as hex text files

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -16,4 +16,9 @@ args:
         long: debug
         multiple: false
         help: Shows debugging information
+    - hex:
+        short: h
+        long: hex
+        multiple: false
+        help: Writes assembly file in a text file containing 16-bit hex values, in addition to the specified binary file (useful for HDL memory loads)
 subcommands:


### PR DESCRIPTION
This file format is useful to load a FPGA block RAM with the contents of a generated ROM during synthesis.