### PR TITLE
Settings to load a base binary to write onto, and filling to a certain size

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -21,4 +21,27 @@ args:
         long: hex
         multiple: false
         help: Writes assembly file in a text file containing 16-bit hex values, in addition to the specified binary file (useful for HDL memory loads)
+    - base:
+        short: b
+        long: base_file
+        multiple: false
+        takes_value: true
+        help: Use an input file as a base and writes on top generated opcodes (i.e. to combine SSP16 code with M68K code)
+    - fill:
+        short: f
+        long: fill
+        multiple: false
+        help: Fills resulting binary file with 0s (until a maximum binary size of 1MB, 2MB or 4MB)
+    - 1M:
+        long: 1meg
+        multiple: false
+        help: chooses maximum binary size of 1MB
+    - 2M:
+        long: 2meg
+        multiple: false
+        help: chooses maximum binary size of 2MB
+    - 4M:
+        long: 4meg
+        multiple: false
+        help: chooses maximum binary size of 4MB
 subcommands:


### PR DESCRIPTION
This PR adds settings to load a base binary (i.e.: a 68K binary file) to write SSP160X on top during the assembly. It also allows resizing the resulting binary file to 3 different settings: 1MB, 2MB and 4MB.